### PR TITLE
[Bug Fix] Use the locale when writing new translations files rather than the first locale

### DIFF
--- a/lib/translation-transform.js
+++ b/lib/translation-transform.js
@@ -8,7 +8,7 @@ const DIR = 'translations';
 module.exports = function(type = 'json') {
   let locales = fs.readdirSync(path.join('app', 'locales'));
   locales.forEach((localeName) => {
-    let content = fs.readFileSync(path.join('app', 'locales', locales[0], 'translations.js'), 'utf8');
+    let content = fs.readFileSync(path.join('app', 'locales', localeName, 'translations.js'), 'utf8');
     let obj = new Function(content.replace('export default', 'return'))();
     let json = JSON.stringify(obj);
     if (!fs.existsSync(DIR)) {


### PR DESCRIPTION
This tripped me up migrating my app which supports several languages.

Thanks for this handy tool!