### PR TITLE
set correct extension for yaml files

### DIFF
--- a/lib/translation-transform.js
+++ b/lib/translation-transform.js
@@ -14,7 +14,8 @@ module.exports = function(type = 'json') {
     if (!fs.existsSync(DIR)) {
       fs.mkdirSync(DIR);
     }
-    fs.writeFileSync(path.join(DIR, `${localeName}.json`), transform(obj, type), 'utf8');
+    let extension = type === 'yaml' ? 'yml' : 'json';
+    fs.writeFileSync(path.join(DIR, `${localeName}.${extension}`), transform(obj, type), 'utf8');
   }, {});
 }
 


### PR DESCRIPTION
The translation transform was setting the extension to `json` even if `type===yaml`. This PR corrects that.