### PR TITLE
Prevents "TypeError: Cannot read property 'name' of undefined"

### DIFF
--- a/lib/codemod.js
+++ b/lib/codemod.js
@@ -29,7 +29,7 @@ module.exports = function(file, api, options) {
   source
     .find(j.ObjectExpression)
     .filter(path => {
-      return path.node.properties.some(prop => prop.key.name === 'i18n');
+      return path.node.properties.some(prop => prop => prop.key != null && prop.key.name === 'i18n');
     })
     .forEach(path => {
       let properties = path.node.properties.map(prop => {


### PR DESCRIPTION
At the moment certain files throw the following error.
ERR ..js Transformation error
TypeError: Cannot read property 'name' of undefined
    at D:/Git/Fusion/UI/codemod.js:32:57
    at Array.some (<anonymous>)

I have done some defensive programming and added `prop => prop.key != null &&` into line 32 to prevent this.